### PR TITLE
Small improvements for build and triangle count file read

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,10 @@ include_directories(${CMAKE_SOURCE_DIR} ${PLATFORM_SOURCE_DIR})
 # Compiler flags
 set(CMAKE_CXX_STANDARD 11)
 
+# require boost
+find_package(Boost REQUIRED)
+include_directories(${Boost_INCLUDE_DIRS})
+
 # Build a list of all the graphblas headers.
 file(GLOB GRAPHBLAS_HEADERS graphblas/*.hpp)
 

--- a/src/demo/triangle_count_demo.cpp
+++ b/src/demo/triangle_count_demo.cpp
@@ -57,9 +57,10 @@ int main(int argc, char **argv)
 //    {
 //        std::cout << "Row: " << row << std::endl;
 //        sscanf(row.c_str(), "%ld\t%ld", &src, &dst);
-    while (infile)
+    while (true)
     {
         infile >> src >> dst;
+        if (infile.eof()) break;
         //std::cout << "Read: " << src << ", " << dst << std::endl;
         if (src > max_id) max_id = src;
         if (dst > max_id) max_id = dst;

--- a/src/test/test_ewiseadd_matrix.cpp
+++ b/src/test/test_ewiseadd_matrix.cpp
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(test_ewiseadd_matrix_masked_bad_dimensions)
                              Mask,
                              GraphBLAS::NoAccumulate(),
                              GraphBLAS::Plus<double>(), mA, mB)),
-        GraphBLAS::DimensionException)
+        GraphBLAS::DimensionException);
         }
 
 //****************************************************************************
@@ -1067,7 +1067,7 @@ BOOST_AUTO_TEST_CASE(test_ewiseadd_matrix_scmp_masked_bad_dimensions)
                              GraphBLAS::complement(Mask),
                              GraphBLAS::NoAccumulate(),
                              GraphBLAS::Plus<double>(), mA, mB)),
-        GraphBLAS::DimensionException)
+        GraphBLAS::DimensionException);
         }
 
 //****************************************************************************

--- a/src/test/test_ewisemult_matrix.cpp
+++ b/src/test/test_ewisemult_matrix.cpp
@@ -652,7 +652,7 @@ BOOST_AUTO_TEST_CASE(test_ewisemult_matrix_masked_bad_dimensions)
                               Mask,
                               GraphBLAS::NoAccumulate(),
                               GraphBLAS::Times<double>(), mA, mB)),
-        GraphBLAS::DimensionException)
+        GraphBLAS::DimensionException);
 }
 
 //****************************************************************************
@@ -1076,7 +1076,7 @@ BOOST_AUTO_TEST_CASE(test_ewisemult_matrix_scmp_masked_bad_dimensions)
                               GraphBLAS::complement(Mask),
                               GraphBLAS::NoAccumulate(),
                               GraphBLAS::Times<double>(), mA, mB)),
-        GraphBLAS::DimensionException)
+        GraphBLAS::DimensionException);
 }
 
 //****************************************************************************


### PR DESCRIPTION
Add find_package for boost.

Insert ; for compilation errors with g++ 9.3.0.

Fix file read in triangle count demo to not read the last line twice.